### PR TITLE
Checking constant defined

### DIFF
--- a/src/Eusonlito/LaravelGettext/Gettext.php
+++ b/src/Eusonlito/LaravelGettext/Gettext.php
@@ -167,10 +167,24 @@ class Gettext
         putenv('LC_TIME='.$locale);
         putenv('LC_MONETARY='.$locale);
 
-        setlocale(LC_MESSAGES, $locale);
-        setlocale(LC_COLLATE, $locale);
-        setlocale(LC_TIME, $locale);
-        setlocale(LC_MONETARY, $locale);
+        if(defined('LC_MESSAGES')) {
+            setlocale(LC_MESSAGES, $locale);
+        }
+        if(defined('LC_COLLATE')) {
+            setlocale(LC_COLLATE, $locale);
+        }
+        if(defined('LC_TIME')) {
+            setlocale(LC_TIME, $locale);
+        }
+        if(defined('LC_MONETARY')) {
+            setlocale(LC_MONETARY, $locale);
+        }
+        if(
+            !defined('LC_MESSAGES') && !defined('LC_COLLATE') &&
+            !defined('LC_TIME') && !defined('LC_MONETARY')
+        ) {
+            setlocale(LC_ALL, $locale);
+        }
 
         if ($this->config['native']) {
             $this->loadNative($locale);

--- a/src/Eusonlito/LaravelGettext/Gettext.php
+++ b/src/Eusonlito/LaravelGettext/Gettext.php
@@ -167,22 +167,23 @@ class Gettext
         putenv('LC_TIME='.$locale);
         putenv('LC_MONETARY='.$locale);
 
-        if(defined('LC_MESSAGES')) {
+        if (defined('LC_MESSAGES')) {
             setlocale(LC_MESSAGES, $locale);
         }
-        if(defined('LC_COLLATE')) {
+
+        if (defined('LC_COLLATE')) {
             setlocale(LC_COLLATE, $locale);
         }
-        if(defined('LC_TIME')) {
+
+        if (defined('LC_TIME')) {
             setlocale(LC_TIME, $locale);
         }
-        if(defined('LC_MONETARY')) {
+
+        if (defined('LC_MONETARY')) {
             setlocale(LC_MONETARY, $locale);
         }
-        if(
-            !defined('LC_MESSAGES') && !defined('LC_COLLATE') &&
-            !defined('LC_TIME') && !defined('LC_MONETARY')
-        ) {
+
+        if (!defined('LC_MESSAGES') && !defined('LC_COLLATE') && !defined('LC_TIME') && !defined('LC_MONETARY')) {
             setlocale(LC_ALL, $locale);
         }
 


### PR DESCRIPTION
`Use of undefined constant LC_MESSAGES - assumed 'LC_MESSAGES'`
According with the documentation, this constant is available only if PHP was compiled with libintl.