### PR TITLE
Removed gettext functions

### DIFF
--- a/src/Eusonlito/LaravelGettext/Gettext.php
+++ b/src/Eusonlito/LaravelGettext/Gettext.php
@@ -211,13 +211,6 @@ class Gettext
 
     private function loadParsed($locale)
     {
-        # Also, we will work with gettext/gettext library
-        # because PHP gones crazy when mo files are updated
-
-        bindtextdomain($this->config['domain'], $this->config['storage']);
-        bind_textdomain_codeset($this->config['domain'], 'UTF-8');
-        textdomain($this->config['domain']);
-
         $file = dirname($this->getFile($this->locale)).'/'.$this->config['domain'];
 
         $translations = null;


### PR DESCRIPTION
If gettext extension is not loaded, the library breaks, even if we are using the parsed mode. This is because it's using `bindtextdomain` and other functions not available.
I suspect they're not needed, so have been removed, other solution is using `function_exists`.