### PR TITLE
[5.5] Support Package Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Begin by installing this package through Composer.
 
 ### Laravel installation
 
+> Note: If you are using Laravel 5.5 or above, the next steps for providers and aliases are unnecessaries. laravel-Gettext supports Laravel new [Package Discovery](https://laravel.com/docs/master/packages#package-discovery).
+
 ```php
 
 // config/app.php

--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,15 @@
         "psr-4": {
             "Eusonlito\\LaravelGettext\\": "src/Eusonlito/LaravelGettext/"
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Eusonlito\\LaravelGettext\\GettextServiceProvider"
+            ],
+            "aliases": {
+                "Gettext": "Eusonlito\\LaravelGettext\\Facade"
+            }
+        }
     }
 }


### PR DESCRIPTION
Laravel 5.5 add a [`Package Discovery`](https://laravel.com/docs/master/packages#package-discovery) feature, that allows the framework discovery packages automatically.

I've also updated the `README.me` to alert users that `laravel-Gettext` support it.